### PR TITLE
Spelling mistake resulting in a bug for 3D regression

### DIFF
--- a/spicy_vki/spicy/spicy_class.py
+++ b/spicy_vki/spicy/spicy_class.py
@@ -1087,7 +1087,7 @@ class spicy:
                                self.c_k, self.basis)
                     ))
                 # Assemble A and b_1, we also rescale b_1
-                self.A = 2*Matrix_Phi_3D_X.T.dot(Matrix_Phi_2D_X)
+                self.A = 2*Matrix_Phi_3D_X.T.dot(Matrix_Phi_3D_X)
                 self.b_1 = 2*Matrix_Phi_3D_X.T.dot(self.u) / self.rescale
                 
         # Laminar model


### PR DESCRIPTION
I fixed a bug that gave an error in the spicy_class.py
line 1090
self.A = 2*Matrix_Phi_3D_X.T.dot(Matrix_Phi_2D_X)
to 
self.A = 2*Matrix_Phi_3D_X.T.dot(Matrix_Phi_3D_X)